### PR TITLE
Support multiple octopus accounts & german translation

### DIFF
--- a/custom_components/octopus_germany/config_flow.py
+++ b/custom_components/octopus_germany/config_flow.py
@@ -61,6 +61,9 @@ class OctopusGermanyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
             if valid:
+                await self.async_set_unique_id(email)
+                self._abort_if_unique_id_configured()
+
                 # Store the complete account data in user_input
                 user_input["account_data"] = account_data
                 return self.async_create_entry(

--- a/custom_components/octopus_germany/translations/de.json
+++ b/custom_components/octopus_germany/translations/de.json
@@ -1,0 +1,46 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Ger\u00e4t ist bereits konfiguriert",
+      "reconfigure_failed": "Neukonfiguration fehlgeschlagen",
+      "reconfigure_successful": "Neukonfiguration erfolgreich"
+    },
+    "error": {
+      "invalid_auth": "E-Mail oder Passwort sind ung\u00fcltig.",
+      "no_accounts": "Keine Konten f\u00fcr diesen Benutzer gefunden",
+      "unknown": "Ein unerwarteter Fehler ist aufgetreten"
+    },
+    "step": {
+      "user": {
+        "title": "Octopus Energy Germany",
+        "description": "Geben Sie Ihre Octopus Energy Germany Zugangsdaten ein",
+        "data": {
+          "email": "E-Mail",
+          "password": "Passwort"
+        }
+      },
+      "reconfigure": {
+        "title": "Octopus Germany neu konfigurieren",
+        "description": "Aktualisieren Sie Ihre Octopus Energy Germany Zugangsdaten. Aktuelle E-Mail: {current_email}",
+        "data": {
+          "email": "E-Mail",
+          "password": "Passwort"
+        }
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "invalid_auth": "E-Mail oder Passwort sind ung\u00fcltig."
+    },
+    "step": {
+      "init": {
+        "title": "Octopus Energy Germany.",
+        "data": {
+          "email": "E-Mail",
+          "password": "Passwort"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I do have multiple octopus accounts that I want to manage:

Multiple octopus accounts could have been added before but all accounts would have the same (first) account behind them. This enables multiple account use.