### PR TITLE
fix: filter dispatches by device_id in binary sensor attributes

### DIFF
--- a/custom_components/octopus_germany/binary_sensor.py
+++ b/custom_components/octopus_germany/binary_sensor.py
@@ -417,15 +417,32 @@ class OctopusIntelligentDispatchingBinarySensor(CoordinatorEntity, BinarySensorE
         if devices and devices[0].get("status"):
             current_state = devices[0]["status"].get("currentState", "Unknown")
 
-        # Format dispatches for display
+        # Format dispatches for display - nur Dispatches fuer dieses Geraet
+        _LOGGER.warning("[DISPATCH DEBUG] device_id=%s, dispatches=%d, first_meta=%s",
+            self._device_id, len(planned_dispatches),
+            planned_dispatches[0].get("meta") if planned_dispatches else "NONE")
+        device_planned = [
+            d for d in planned_dispatches
+            if d.get("deviceId") == self._device_id
+            or d.get("meta", {}).get("deviceId") == self._device_id
+        ]
+        _LOGGER.warning("[DISPATCH DEBUG] device_planned count=%d", len(device_planned))
         formatted_planned_dispatches = []
-        for dispatch in planned_dispatches:
+        for dispatch in device_planned:
             formatted = self._format_dispatch(dispatch)
             if formatted:
                 formatted_planned_dispatches.append(formatted)
 
+        device_completed = [
+            d for d in completed_dispatches
+            if d.get("deviceId") == self._device_id
+            or d.get("meta", {}).get("deviceId") == self._device_id
+        ]
+        # Fallback: completedDispatches kommen ohne deviceId (andere API-Quelle)
+        if not device_completed:
+            device_completed = completed_dispatches
         formatted_completed_dispatches = []
-        for dispatch in completed_dispatches:
+        for dispatch in device_completed:
             formatted = self._format_dispatch(dispatch)
             if formatted:
                 formatted_completed_dispatches.append(formatted)


### PR DESCRIPTION
## Problem

When multiple EVs are registered on one Octopus account, the `planned_dispatches` and `completed_dispatches` attributes of the `binary_sensor.octopus_..._intelligent_dispatching` entities contained **all dispatches for all devices** — not just the dispatches for that sensor's own device.

This caused the Lovelace dashboard to display identical (and duplicated) charging schedules for all vehicles.

### Root cause

In `_update_attributes()`, the code iterated over the full `planned_dispatches` list without filtering by `self._device_id`:

```python
# Before (bug): all dispatches for all devices
for dispatch in planned_dispatches:
    formatted = self._format_dispatch(dispatch)
    ...
```

`_get_active_dispatch()` already performed the correct per-device filtering using `deviceId` / `meta.deviceId` — `_update_attributes()` did not.

The `fetch_flex_planned_dispatches()` method in `octopus_germany.py` correctly sets `meta.deviceId = device_id` for each transformed dispatch, so the information is available.

## Fix

Apply the same `device_id` filter before formatting dispatches for the sensor attributes:

```python
# After (fix): only dispatches for this device
device_planned = [
    d for d in planned_dispatches
    if d.get("deviceId") == self._device_id
    or d.get("meta", {}).get("deviceId") == self._device_id
]
```

For `completed_dispatches`, the same filter is applied with a fallback to all dispatches when no device-tagged entries are found (the completed dispatch API does not always include `deviceId`).

## Testing

Tested with two Tesla EVs (Model 3 + Model Y) on one Octopus Germany account. After the fix:
- `binary_sensor...tesla_model_3_intelligent_dispatching` shows only Model 3 planned dispatches
- `binary_sensor...tesla_model_y_intelligent_dispatching` shows only Model Y planned dispatches

**Note:** A full HA restart is required after patching — `config_entry` reload alone does not re-import the Python module.