### PR TITLE
Add activePower sensor for EV charging power

### DIFF
--- a/custom_components/octopus_germany/octopus_germany.py
+++ b/custom_components/octopus_germany/octopus_germany.py
@@ -181,6 +181,10 @@ query ComprehensiveDataQuery($accountNumber: String!) {
       currentState
       isSuspended
             ... on SmartFlexVehicleStatus {
+                activePower {
+                    value
+                    timestamp
+                }
                 stateOfCharge {
                     value
                     timestamp
@@ -247,6 +251,10 @@ query ComprehensiveDataQuery($accountNumber: String!) {
         currentState
         isSuspended
                 ... on SmartFlexVehicleStatus {
+                    activePower {
+                        value
+                        timestamp
+                    }
                     stateOfCharge {
                         value
                         timestamp

--- a/custom_components/octopus_germany/sensor.py
+++ b/custom_components/octopus_germany/sensor.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     STATE_UNAVAILABLE,
     UnitOfEnergy,
+    UnitOfPower,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -280,6 +281,12 @@ async def async_setup_entry(
 
                             entities.append(
                                 OctopusVehicleBatterySizeSensor(
+                                    acc_num, coordinator, device_id
+                                )
+                            )
+
+                            entities.append(
+                                OctopusVehicleActivePowerSensor(
                                     acc_num, coordinator, device_id
                                 )
                             )
@@ -2319,6 +2326,24 @@ class OctopusVehicleBatterySizeSensor(OctopusVehicleDataSensor):
 
         vehicle_variant = device.get("vehicleVariant", {}) or {}
         return self._to_float(vehicle_variant.get("batterySize"))
+
+
+class OctopusVehicleActivePowerSensor(OctopusVehicleDataSensor):
+    """Sensor for current EV charging power in kW."""
+
+    _metric_name = "Active Power"
+    _metric_unique_id = "active_power"
+    _metric_icon = "mdi:lightning-bolt"
+    _metric_device_class = SensorDeviceClass.POWER
+    _metric_unit = UnitOfPower.KILO_WATT
+
+    def _get_metric_value(self) -> float | None:
+        device = self._get_device_data()
+        if not device:
+            return None
+        status = device.get("status", {}) or {}
+        active_power = status.get("activePower", {}) or {}
+        return self._to_float(active_power.get("value"))
 
 
 class OctopusElectricitySmartMeterReadingsSensor(


### PR DESCRIPTION
## Summary

- Adds `activePower` to the `SmartFlexVehicleStatus` inline fragment in `COMPREHENSIVE_QUERY` (both occurrences) — it is a `DecimalReading` object with `value` and `timestamp`, same structure as `stateOfCharge`
- Adds a new `OctopusVehicleActivePowerSensor` entity per vehicle, exposing the current charging power in kW
- Registers the new sensor in `async_setup_entry` alongside the existing EV sensors

## Result

A new sensor `Octopus <account> <vehicle> Active Power` appears in Home Assistant for each electric vehicle, showing the live charging power (e.g. `11.111` kW when charging, `0.0` when idle).

## Test plan

- [x] Confirm `activePower` is returned in the GraphQL response for a vehicle that is actively charging
- [x] Verify the sensor shows the correct kW value in HA Developer Tools → States
- [x] Verify the sensor shows `0.0` when the vehicle is not charging
- [x] Verify no regression on existing vehicle sensors (SoC, Battery Size)