### PR TITLE
Reduce queries simply

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ LOG_API_RESPONSES = True
 ```
 After restarting HA the API-Responses and additional information will be in debug log.
 
+To poll account/device state more often while developing, set the environment variable `OCTOPUS_GERMANY_UPDATE_INTERVAL` to a number of minutes (for example `1`) and restart Home Assistant. Yesterday's meter readings still refresh at most every 3 hours.
+
 
 ## API Support
 

--- a/TECHNICAL_NOTES.md
+++ b/TECHNICAL_NOTES.md
@@ -129,7 +129,10 @@ logger:
 
 #### Performance Considerations
 
-- **Update Interval**: 1 minute (configurable)
+- **Account/device poll**: 15 minutes (balances, dispatch, tariffs)
+- **Smart meter readings**: at most every 3 hours (yesterday's intervals; last result reused in between)
+- **Token refresh**: every 50 minutes
+- **Local testing**: set `OCTOPUS_GERMANY_UPDATE_INTERVAL` (minutes) and restart Home Assistant
 - **API Call Throttling**: Prevents excessive requests
 - **Cached Data Fallback**: Returns last known data on API failures
 - **Efficient GraphQL**: Single query fetches all account data

--- a/custom_components/octopus_germany/__init__.py
+++ b/custom_components/octopus_germany/__init__.py
@@ -16,7 +16,14 @@ from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util.dt import utcnow, as_utc, parse_datetime
 
-from .const import DOMAIN, CONF_EMAIL, CONF_PASSWORD, UPDATE_INTERVAL, DEBUG_ENABLED
+from .const import (
+    DOMAIN,
+    CONF_EMAIL,
+    CONF_PASSWORD,
+    UPDATE_INTERVAL,
+    DEBUG_ENABLED,
+    MEASUREMENTS_UPDATE_INTERVAL_HOURS,
+)
 from .octopus_germany import OctopusGermany
 
 import voluptuous as vol
@@ -419,9 +426,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     break
                 except ValueError, TypeError:
                     pass
-        result_data[account_number]["vehicle_battery_size_in_kwh"] = (
-            vehicle_battery_size
-        )
+        result_data[account_number][
+            "vehicle_battery_size_in_kwh"
+        ] = vehicle_battery_size
 
         # Handle dispatch data if it exists
         # Try to fall back to cached data from coordinator if API omits the field
@@ -956,9 +963,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             except (ValueError, TypeError) as e:
                 _LOGGER.warning("Error calculating gas contract expiry days: %s", e)
 
-        result_data[account_number]["gas_contract_days_until_expiry"] = (
-            gas_contract_days_until_expiry
-        )
+        result_data[account_number][
+            "gas_contract_days_until_expiry"
+        ] = gas_contract_days_until_expiry
 
         # Gas meter smart reading capability
         gas_meter_smart_reading = None
@@ -1037,17 +1044,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     str(e),
                 )
 
-        result_data[account_number]["electricity_latest_reading"] = (
-            electricity_latest_reading
-        )
+        result_data[account_number][
+            "electricity_latest_reading"
+        ] = electricity_latest_reading
 
         # Extract smart meter readings if available
         electricity_smart_meter_readings = data.get(
             "electricity_smart_meter_readings", []
         )
-        result_data[account_number]["electricity_smart_meter_readings"] = (
-            electricity_smart_meter_readings
-        )
+        result_data[account_number][
+            "electricity_smart_meter_readings"
+        ] = electricity_smart_meter_readings
 
         if electricity_smart_meter_readings:
             _LOGGER.debug(
@@ -1061,11 +1068,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # --- Statistics import for HA energy dashboard ---
     # Tracks which dates have been imported per account to avoid redundant API calls
     imported_stats_dates: dict[str, set[str]] = {acc: set() for acc in account_numbers}
+    last_stats_import_at = None
 
     async def async_import_consumption_statistics():
         """Import 15-min smart meter data into HA long-term statistics for the energy dashboard."""
         if not HAS_RECORDER:
             return
+
+        nonlocal last_stats_import_at
+        now = datetime.now()
+        if last_stats_import_at is not None and now - last_stats_import_at < timedelta(
+            hours=MEASUREMENTS_UPDATE_INTERVAL_HOURS
+        ):
+            return
+        last_stats_import_at = now
 
         for account_num in account_numbers:
             if not coordinator.data or account_num not in coordinator.data:
@@ -1232,9 +1248,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
             _LOGGER.info(
                 "First planned dispatch: %s",
-                coordinator.data[primary_account_number]["plannedDispatches"][0]
-                if coordinator.data[primary_account_number]["plannedDispatches"]
-                else "None",
+                (
+                    coordinator.data[primary_account_number]["plannedDispatches"][0]
+                    if coordinator.data[primary_account_number]["plannedDispatches"]
+                    else "None"
+                ),
             )
 
     # Import consumption statistics after each coordinator refresh

--- a/custom_components/octopus_germany/const.py
+++ b/custom_components/octopus_germany/const.py
@@ -1,12 +1,21 @@
 """Constants for the Octopus Germany integration."""
 
+import os
+
 DOMAIN = "octopus_germany"
 
 CONF_EMAIL = "email"
 CONF_PASSWORD = "password"
 
-# Debug interval settings
-UPDATE_INTERVAL = 1  # Update interval in minutes (set to 1 for faster testing)
+# Account/device polling (balances, dispatch, tariffs). Override in minutes
+# with OCTOPUS_GERMANY_UPDATE_INTERVAL for local testing.
+_DEFAULT_UPDATE_INTERVAL_MINUTES = 15
+UPDATE_INTERVAL = int(
+    os.environ.get("OCTOPUS_GERMANY_UPDATE_INTERVAL", _DEFAULT_UPDATE_INTERVAL_MINUTES)
+)
+
+# Smart meter interval data at Octopus is ingested in a batch every 3-4 hours.
+MEASUREMENTS_UPDATE_INTERVAL_HOURS = 3
 
 # Schema exploration (run once for debugging)
 EXPLORE_SCHEMA_ONCE = True  # Set to True to run schema exploration once

--- a/custom_components/octopus_germany/octopus_germany.py
+++ b/custom_components/octopus_germany/octopus_germany.py
@@ -532,6 +532,7 @@ query getSmartMeterUsageV2($accountNumber: String!, $propertyId: ID!, $date: Dat
       measurements(
         utilityFilters: {electricityFilters: {readingFrequencyType: HOUR_INTERVAL, readingQuality: COMBINED}}
         startOn: $date
+        endOn: $date
         first: 24
       ) {
         edges {
@@ -589,6 +590,7 @@ query getSmartMeterUsage($accountNumber: String!, $propertyId: ID!, $date: Date!
       measurements(
         utilityFilters: {electricityFilters: {readingFrequencyType: HOUR_INTERVAL, readingQuality: COMBINED}}
         startOn: $date
+        endOn: $date
         first: 24
       ) {
         edges {
@@ -614,6 +616,7 @@ query getSmartMeter15Min($accountNumber: String!, $propertyId: ID!, $date: Date!
       measurements(
         utilityFilters: {electricityFilters: {readingFrequencyType: RAW_INTERVAL, readingQuality: COMBINED}}
         startOn: $date
+        endOn: $date
         first: 96
       ) {
         edges {

--- a/custom_components/octopus_germany/octopus_germany.py
+++ b/custom_components/octopus_germany/octopus_germany.py
@@ -12,7 +12,11 @@ import asyncio
 import jwt
 from homeassistant.exceptions import ConfigEntryNotReady
 from python_graphql_client import GraphqlClient
-from .const import TOKEN_AUTO_REFRESH_INTERVAL, TOKEN_REFRESH_MARGIN
+from .const import (
+    MEASUREMENTS_UPDATE_INTERVAL_HOURS,
+    TOKEN_AUTO_REFRESH_INTERVAL,
+    TOKEN_REFRESH_MARGIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -882,6 +886,9 @@ class OctopusGermany:
         # Start the auto-refresh task immediately
         asyncio.create_task(self._token_manager.start_auto_refresh())
 
+        self._last_measurements_fetch_at = {}
+        self._measurements_cache = {}
+
     @property
     def _token(self):
         """Get the current token from the token manager."""
@@ -959,9 +966,9 @@ class OctopusGermany:
                                 masked_token = (
                                     token[:5] + "*" * mask_length + token[-5:]
                                 )
-                                safe_response["data"]["obtainKrakenToken"]["token"] = (
-                                    masked_token
-                                )
+                                safe_response["data"]["obtainKrakenToken"][
+                                    "token"
+                                ] = masked_token
                         _LOGGER.info(
                             "Token response (partial): %s",
                             json.dumps(safe_response, indent=2),
@@ -1414,7 +1421,18 @@ class OctopusGermany:
 
                 # Fetch electricity smart meter readings if property data is available
                 try:
-                    if (
+                    now = datetime.now()
+                    last_fetch = self._last_measurements_fetch_at.get(account_number)
+                    measurements_due = (
+                        last_fetch is None
+                        or now - last_fetch
+                        >= timedelta(hours=MEASUREMENTS_UPDATE_INTERVAL_HOURS)
+                    )
+                    if not measurements_due:
+                        cached = self._measurements_cache.get(account_number)
+                        if cached:
+                            result.update(cached)
+                    elif (
                         result.get("account")
                         and "allProperties" in result["account"]
                         and result["account"]["allProperties"]
@@ -1467,7 +1485,6 @@ class OctopusGermany:
                                     for date_str, label in test_dates
                                 ],
                             )
-
                             smart_meter_readings = None
                             successful_date = None
 
@@ -1503,16 +1520,21 @@ class OctopusGermany:
                                         date_str,
                                     )
 
+                            self._last_measurements_fetch_at[account_number] = now
                             if smart_meter_readings:
-                                result["electricity_smart_meter_readings"] = (
-                                    smart_meter_readings
-                                )
-                                result["electricity_smart_meter_readings_date"] = (
-                                    successful_date[0]
-                                )
-                                result["electricity_smart_meter_readings_label"] = (
-                                    successful_date[1]
-                                )
+                                cached = {
+                                    "electricity_smart_meter_readings": (
+                                        smart_meter_readings
+                                    ),
+                                    "electricity_smart_meter_readings_date": (
+                                        successful_date[0]
+                                    ),
+                                    "electricity_smart_meter_readings_label": (
+                                        successful_date[1]
+                                    ),
+                                }
+                                self._measurements_cache[account_number] = cached
+                                result.update(cached)
                             else:
                                 _LOGGER.warning(
                                     "No smart meter readings found for any tested date"
@@ -1527,15 +1549,19 @@ class OctopusGermany:
                                 )
 
                                 if smart_meter_readings_v2:
-                                    result["electricity_smart_meter_readings"] = (
-                                        smart_meter_readings_v2
-                                    )
-                                    result["electricity_smart_meter_readings_date"] = (
-                                        yesterday.isoformat()
-                                    )
-                                    result["electricity_smart_meter_readings_label"] = (
-                                        "yesterday_v2"
-                                    )
+                                    cached = {
+                                        "electricity_smart_meter_readings": (
+                                            smart_meter_readings_v2
+                                        ),
+                                        "electricity_smart_meter_readings_date": (
+                                            yesterday.isoformat()
+                                        ),
+                                        "electricity_smart_meter_readings_label": (
+                                            "yesterday_v2"
+                                        ),
+                                    }
+                                    self._measurements_cache[account_number] = cached
+                                    result.update(cached)
                                     _LOGGER.info(
                                         "Successfully fetched %d smart meter readings with V2 query for yesterday",
                                         len(smart_meter_readings_v2),
@@ -2855,16 +2881,18 @@ class OctopusGermany:
                                 "name": type_name,
                                 "kind": type_def.get("kind"),
                                 "description": type_def.get("description"),
-                                "fields": [
-                                    {
-                                        "name": field.get("name"),
-                                        "description": field.get("description"),
-                                        "type": field.get("type", {}).get("name"),
-                                    }
-                                    for field in type_def.get("fields", [])
-                                ]
-                                if type_def.get("fields")
-                                else [],
+                                "fields": (
+                                    [
+                                        {
+                                            "name": field.get("name"),
+                                            "description": field.get("description"),
+                                            "type": field.get("type", {}).get("name"),
+                                        }
+                                        for field in type_def.get("fields", [])
+                                    ]
+                                    if type_def.get("fields")
+                                    else []
+                                ),
                             }
                         )
 

--- a/custom_components/octopus_germany/octopus_germany.py
+++ b/custom_components/octopus_germany/octopus_germany.py
@@ -1461,123 +1461,31 @@ class OctopusGermany:
                                 # Mark as explored to prevent repeated exploration
                                 self._schema_explored = True
 
-                            # Get multiple dates for testing: today, yesterday, day before yesterday
                             from datetime import date, timedelta
 
-                            today = date.today()
-                            yesterday = today - timedelta(days=1)
-                            day_before_yesterday = today - timedelta(days=2)
-                            week_ago = today - timedelta(days=7)
-                            month_ago = today - timedelta(days=30)
-
-                            test_dates = [
-                                (today.isoformat(), "today"),
-                                (yesterday.isoformat(), "yesterday"),
-                                (
-                                    day_before_yesterday.isoformat(),
-                                    "day_before_yesterday",
-                                ),
-                                (week_ago.isoformat(), "week_ago"),
-                                (month_ago.isoformat(), "month_ago"),
-                            ]
-
-                            _LOGGER.info(
-                                "Testing smart meter readings for multiple dates: %s",
-                                [
-                                    f"{label} ({date_str})"
-                                    for date_str, label in test_dates
-                                ],
+                            yesterday = (date.today() - timedelta(days=1)).isoformat()
+                            readings = (
+                                await self.fetch_electricity_smart_meter_readings_v2(
+                                    account_number, property_id, yesterday
+                                )
                             )
-                            smart_meter_readings = None
-                            successful_date = None
-
-                            # Test each date until we find data
-                            for date_str, date_label in test_dates:
-                                _LOGGER.debug(
-                                    "Fetching electricity smart meter readings for property %s on %s (%s)",
-                                    property_id,
-                                    date_str,
-                                    date_label,
-                                )
-
-                                readings = (
-                                    await self.fetch_electricity_smart_meter_readings(
-                                        account_number, property_id, date_str
-                                    )
-                                )
-
-                                if readings:
-                                    smart_meter_readings = readings
-                                    successful_date = (date_str, date_label)
-                                    _LOGGER.info(
-                                        "Successfully fetched %d smart meter readings for %s (%s)",
-                                        len(readings),
-                                        date_label,
-                                        date_str,
-                                    )
-                                    break
-                                else:
-                                    _LOGGER.debug(
-                                        "No smart meter readings found for %s (%s)",
-                                        date_label,
-                                        date_str,
-                                    )
-
                             self._last_measurements_fetch_at[account_number] = now
-                            if smart_meter_readings:
+                            if readings:
                                 cached = {
-                                    "electricity_smart_meter_readings": (
-                                        smart_meter_readings
-                                    ),
-                                    "electricity_smart_meter_readings_date": (
-                                        successful_date[0]
-                                    ),
+                                    "electricity_smart_meter_readings": readings,
+                                    "electricity_smart_meter_readings_date": yesterday,
                                     "electricity_smart_meter_readings_label": (
-                                        successful_date[1]
+                                        "yesterday"
                                     ),
                                 }
                                 self._measurements_cache[account_number] = cached
                                 result.update(cached)
                             else:
-                                _LOGGER.warning(
-                                    "No smart meter readings found for any tested date"
+                                _LOGGER.debug(
+                                    "No smart meter readings for property %s on %s",
+                                    property_id,
+                                    yesterday,
                                 )
-
-                                # Try V2 query with yesterday's date as fallback
-                                _LOGGER.info(
-                                    "Trying V2 query with yesterday's date as fallback"
-                                )
-                                smart_meter_readings_v2 = await self.fetch_electricity_smart_meter_readings_v2(
-                                    account_number, property_id, yesterday.isoformat()
-                                )
-
-                                if smart_meter_readings_v2:
-                                    cached = {
-                                        "electricity_smart_meter_readings": (
-                                            smart_meter_readings_v2
-                                        ),
-                                        "electricity_smart_meter_readings_date": (
-                                            yesterday.isoformat()
-                                        ),
-                                        "electricity_smart_meter_readings_label": (
-                                            "yesterday_v2"
-                                        ),
-                                    }
-                                    self._measurements_cache[account_number] = cached
-                                    result.update(cached)
-                                    _LOGGER.info(
-                                        "Successfully fetched %d smart meter readings with V2 query for yesterday",
-                                        len(smart_meter_readings_v2),
-                                    )
-                                else:
-                                    _LOGGER.warning(
-                                        "No smart meter readings available with any query or date - checking property structure"
-                                    )
-                                    # Log the entire property structure for debugging
-                                    _LOGGER.info(
-                                        "Property data structure: %s",
-                                        json.dumps(property_data, indent=2),
-                                    )
                         else:
                             _LOGGER.debug(
                                 "No property ID found for smart meter readings"


### PR DESCRIPTION
This PR implements simple changes to reduce the amount of calls this project makes to the Octopus Measurements API, which at this moment can exceed 35 thousand calls per user per day, in some cases. 
The status quo makes this many calls possible via:
```
1440 ticks/day
× 6 measurements queries
× x number of user accounts
= 8,640 resolves/day **per account**
``` 
So a user with 1 account will make 8k calls a day, a user with 2 will make 17k, etc. 

Octopus only updates readings once every 3-4 hours; there is no need to poll once per minute. This PR cut down the call count to something more responsible. 

Suggested future work: 
Instead of one call per day, use entire desired range in the `startOn` and `endOn` and make use of pagination; especially for the yearly query. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217550892436665